### PR TITLE
更改 evaluate-interview 的参数

### DIFF
--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -193,7 +193,7 @@ export function registerTools(server: FastMCP) {
   server.addTool({
     name: "evaluate-interview",
     description:
-      "Evaluate the interviewer's performance based on the interview conversation, Use this tool when mentions /e",
+      "Evaluate the interviewee's performance based on the interview conversation, Use this tool when mentions /e",
     parameters: z.object({
       position: z
         .enum(["frontend", "backend", "test", "ui", "ux"])


### PR DESCRIPTION
你好，

我发现 evaluate-interview 这个 MCP 的 description 写错了，我根据 EVALUATE prompt 的理解应该是评价面试者的 面试情况，所以应该是 interviewee 
